### PR TITLE
Library translation registering

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kano-i18n (3.5-1) unstable; urgency=low
+
+  * Added `register_domain` function for libraries to register their
+    translations.
+
+ -- Team Kano <dev@kano.me>  Fri, 19 Aug 2016 15:45:00 +0000
+
 kano-i18n (1.0-1) unstable; urgency=low
 
   * Initial release.

--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -34,7 +34,7 @@ def register_domain(domain, locale_dir=None):
     global REGISTERED_DOMAINS
     global CURRENT_TRANSLATION
 
-    if not hasattr(__builtin__, '_'):
+    if not hasattr(__builtin__, '_') or not CURRENT_TRANSLATION:
         # TODO
         raise Exception('Localization has not been setup')
 

--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -9,8 +9,50 @@
 import gettext
 import __builtin__
 
+REGISTERED_DOMAINS = set()
+CURRENT_TRANSLATION = None
+
+
 def install(app, locale_dir=None):
+    global CURRENT_TRANSLATION
+
     # N_() defined globally for deferred translation
     __builtin__.__dict__['N_'] = lambda msg: msg
 
-    gettext.install(app, localedir=locale_dir, unicode=1)
+    trans = gettext.translation(app, localedir=locale_dir, fallback=True, codeset=None)
+    trans.install(True, names=None)
+
+    CURRENT_TRANSLATION = trans
+
+
+def register_domain(domain, locale_dir=None):
+    """
+    Register a domain as a fallback to the currently installed translation.
+    Used by library modules to register their translations on top of the current
+    app translation.
+    """
+    global REGISTERED_DOMAINS
+    global CURRENT_TRANSLATION
+
+    if not hasattr(__builtin__, '_'):
+        # TODO
+        raise Exception('Localization has not been setup')
+
+    if domain in REGISTERED_DOMAINS:
+        # Already setup so we bail early here
+        return
+
+    # Create translation
+    trans = gettext.translation(
+        domain,
+        localedir=locale_dir,
+        fallback=True  # don't throw an error if the no .mo files found for domain, just return `NullTranslations`
+    )
+
+    CURRENT_TRANSLATION.add_fallback(trans)
+    REGISTERED_DOMAINS.add(domain)
+
+
+def get_current_translation():
+    global CURRENT_TRANSLATION
+    return CURRENT_TRANSLATION

--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -10,6 +10,7 @@ import gettext
 import __builtin__
 
 REGISTERED_DOMAINS = set()
+DOMAINS_TO_REGISTER = []
 CURRENT_TRANSLATION = None
 
 
@@ -24,19 +25,30 @@ def install(app, locale_dir=None):
 
     CURRENT_TRANSLATION = trans
 
+    if len(DOMAINS_TO_REGISTER) > 0:
+        for domain in DOMAINS_TO_REGISTER:
+            register_domain(*domain)
+
 
 def register_domain(domain, locale_dir=None):
     """
     Register a domain as a fallback to the currently installed translation.
+    If there is no currently installed translation then queue it up to be
+    registered when `install` is called.
+
     Used by library modules to register their translations on top of the current
     app translation.
     """
     global REGISTERED_DOMAINS
     global CURRENT_TRANSLATION
+    global DOMAINS_TO_REGISTER
 
     if not hasattr(__builtin__, '_') or not CURRENT_TRANSLATION:
-        # TODO
-        raise Exception('Localization has not been setup')
+        # Install hasn't been called yet so defer setup
+        DOMAINS_TO_REGISTER.append(
+            (domain, locale_dir)
+        )
+        return
 
     if domain in REGISTERED_DOMAINS:
         # Already setup so we bail early here

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -1,0 +1,62 @@
+import base64
+import os
+import pytest
+from gettext import GNUTranslations, NullTranslations
+from test.test_support import EnvironmentVarGuard
+
+from kano_i18n.init import register_domain, install, get_current_translation
+
+
+# From cpython test_gettext.py
+GNU_MO_DATA = '''\
+3hIElQAAAAAGAAAAHAAAAEwAAAALAAAAfAAAAAAAAACoAAAAFQAAAKkAAAAjAAAAvwAAAKEAAADj
+AAAABwAAAIUBAAALAAAAjQEAAEUBAACZAQAAFgAAAN8CAAAeAAAA9gIAAKEAAAAVAwAABQAAALcD
+AAAJAAAAvQMAAAEAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABQAAAAYAAAACAAAAAFJh
+eW1vbmQgTHV4dXJ5IFlhY2gtdABUaGVyZSBpcyAlcyBmaWxlAFRoZXJlIGFyZSAlcyBmaWxlcwBU
+aGlzIG1vZHVsZSBwcm92aWRlcyBpbnRlcm5hdGlvbmFsaXphdGlvbiBhbmQgbG9jYWxpemF0aW9u
+CnN1cHBvcnQgZm9yIHlvdXIgUHl0aG9uIHByb2dyYW1zIGJ5IHByb3ZpZGluZyBhbiBpbnRlcmZh
+Y2UgdG8gdGhlIEdOVQpnZXR0ZXh0IG1lc3NhZ2UgY2F0YWxvZyBsaWJyYXJ5LgBtdWxsdXNrAG51
+ZGdlIG51ZGdlAFByb2plY3QtSWQtVmVyc2lvbjogMi4wClBPLVJldmlzaW9uLURhdGU6IDIwMDAt
+MDgtMjkgMTI6MTktMDQ6MDAKTGFzdC1UcmFuc2xhdG9yOiBKLiBEYXZpZCBJYsOhw7FleiA8ai1k
+YXZpZEBub29zLmZyPgpMYW5ndWFnZS1UZWFtOiBYWCA8cHl0aG9uLWRldkBweXRob24ub3JnPgpN
+SU1FLVZlcnNpb246IDEuMApDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9aXNvLTg4
+NTktMQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBub25lCkdlbmVyYXRlZC1CeTogcHlnZXR0
+ZXh0LnB5IDEuMQpQbHVyYWwtRm9ybXM6IG5wbHVyYWxzPTI7IHBsdXJhbD1uIT0xOwoAVGhyb2F0
+d29iYmxlciBNYW5ncm92ZQBIYXkgJXMgZmljaGVybwBIYXkgJXMgZmljaGVyb3MAR3V2ZiB6YnFo
+eXIgY2ViaXZxcmYgdmFncmVhbmd2YmFueXZtbmd2YmEgbmFxIHlicG55dm1uZ3ZiYQpmaGNjYmVn
+IHNiZSBsYmhlIENsZ3ViYSBjZWJ0ZW56ZiBvbCBjZWJpdnF2YXQgbmEgdmFncmVzbnByIGdiIGd1
+ciBUQUgKdHJnZ3JrZyB6cmZmbnRyIHBuZ255YnQgeXZvZW5lbC4AYmFjb24Ad2luayB3aW5rAA==
+'''
+
+
+@pytest.yield_fixture
+def test_env():
+    with EnvironmentVarGuard() as env:
+        yield env
+
+
+def test_register_domain_fallback(tmpdir, test_env):
+    test_env['LANG'] = 'en_GB'
+    locale_dir = tmpdir.ensure('en_GB', 'LC_MESSAGES', dir=True)
+
+    # setup top level domain (has no translations)
+    install('app-domain', locale_dir=tmpdir.strpath)
+
+    domain1_mo = os.path.join(locale_dir.strpath, 'domain-1.mo')
+    with open(domain1_mo, 'wb') as fp:
+        fp.write(base64.decodestring(GNU_MO_DATA))
+
+    # register a new domain (with translations)
+    register_domain('domain-1', locale_dir=tmpdir.strpath)
+
+    # inspect domain setup
+    current_translation = get_current_translation()
+    assert current_translation is not None
+    assert isinstance(current_translation, NullTranslations)
+    assert current_translation._fallback is not None
+    assert current_translation._fallback._fallback is None
+    assert isinstance(current_translation._fallback, GNUTranslations)
+
+    # No translation defined
+    assert _('Hi') == 'Hi'
+    assert _('nudge nudge') == 'wink wink'

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -39,7 +39,8 @@ def test_env():
 def setup_function(function):
     # Clear global variables before each test
     kano_i18n.init.REGISTERED_DOMAINS.clear()
-    kano_i18n.CURRENT_TRANSLATION = None
+    kano_i18n.init.CURRENT_TRANSLATION = None
+    kano_i18n.init.DOMAINS_TO_REGISTER = []
 
 
 def test_register_domain_fallback(tmpdir, test_env):
@@ -90,3 +91,23 @@ def test_register_domain_fallback_duplicate():
     register_domain('domain-2')
     assert current_translation._fallback is not None
     assert current_translation._fallback._fallback is not None
+
+
+def test_register_domain_deffered():
+    """Registering a domain before install is called should queue it up to be
+    registered later"""
+
+    assert get_current_translation() is None
+
+    register_domain('domain-1')
+    register_domain('domain-1')
+    register_domain('domain-2')
+    assert get_current_translation() is None
+
+    install('test-domain')
+
+    current_translation = get_current_translation()
+    assert current_translation is not None
+    assert current_translation._fallback is not None  # domain-1
+    assert current_translation._fallback._fallback is not None  # domain-2
+    assert current_translation._fallback._fallback._fallback is None

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -8,7 +8,7 @@ import kano_i18n.init
 from kano_i18n.init import register_domain, install, get_current_translation
 
 
-# From cpython test_gettext.py
+# Test mo file (from cpython test_gettext.py)
 GNU_MO_DATA = '''\
 3hIElQAAAAAGAAAAHAAAAEwAAAALAAAAfAAAAAAAAACoAAAAFQAAAKkAAAAjAAAAvwAAAKEAAADj
 AAAABwAAAIUBAAALAAAAjQEAAEUBAACZAQAAFgAAAN8CAAAeAAAA9gIAAKEAAAAVAwAABQAAALcD
@@ -64,9 +64,8 @@ def test_register_domain_fallback(tmpdir, test_env):
     assert current_translation._fallback._fallback is None
     assert isinstance(current_translation._fallback, GNUTranslations)
 
-    # No translation defined
     assert _('Hi') == 'Hi'
-    assert _('nudge nudge') == 'wink wink'
+    assert _('nudge nudge') == 'wink wink'  # Translation comes from domain-1
 
 
 def test_register_domain_fallback_duplicate():

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -37,7 +37,7 @@ def test_env():
 
 
 def setup_function(function):
-    # Clear global variables
+    # Clear global variables before each test
     kano_i18n.init.REGISTERED_DOMAINS.clear()
     kano_i18n.CURRENT_TRANSLATION = None
 
@@ -74,23 +74,20 @@ def test_register_domain_fallback_duplicate():
 
     install('app-domain')
 
-    register_domain('domain-1')
-
-    # inspect domain setup
     current_translation = get_current_translation()
     assert current_translation is not None
+    assert current_translation._fallback is None
+
+    register_domain('domain-1')
     assert current_translation._fallback is not None
     assert current_translation._fallback._fallback is None
 
     # register domain again
     register_domain('domain-1')
-    current_translation = get_current_translation()
     assert current_translation._fallback is not None
     assert current_translation._fallback._fallback is None
 
     # register different domain
     register_domain('domain-2')
-
-    current_translation = get_current_translation()
     assert current_translation._fallback is not None
     assert current_translation._fallback._fallback is not None


### PR DESCRIPTION
First stab at implementing an `register_domain` method that libraries can use to register their translations.