### PR TITLE
Ensure that N_ returns unicode

### DIFF
--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -14,11 +14,17 @@ DOMAINS_TO_REGISTER = []
 CURRENT_TRANSLATION = None
 
 
+def deferred_translation(msg):
+    if isinstance(msg, unicode):
+        return msg
+    return unicode(msg, encoding='utf8')  # Assume original string is utf8 encoded
+
+
 def install(app, locale_dir=None):
     global CURRENT_TRANSLATION
 
     # N_() defined globally for deferred translation
-    __builtin__.__dict__['N_'] = lambda msg: unicode(msg)
+    __builtin__.__dict__['N_'] = deferred_translation
 
     trans = gettext.translation(app, localedir=locale_dir, fallback=True, codeset=None)
     trans.install(True, names=None)
@@ -48,6 +54,9 @@ def register_domain(domain, locale_dir=None):
         DOMAINS_TO_REGISTER.append(
             (domain, locale_dir)
         )
+        # and register stubs for _ and N_
+        __builtin__.__dict__['_'] = lambda msg: msg
+        __builtin__.__dict__['N_'] = lambda msg: msg
         return
 
     if domain in REGISTERED_DOMAINS:

--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -20,6 +20,12 @@ def deferred_translation(msg):
     return unicode(msg, encoding='utf8')  # Assume original string is utf8 encoded
 
 
+def translation_stub(msg):
+    if isinstance(msg, unicode):
+        return msg.encode('ascii', 'replace')
+    return msg
+
+
 def install(app, locale_dir=None):
     global CURRENT_TRANSLATION
 
@@ -55,8 +61,8 @@ def register_domain(domain, locale_dir=None):
             (domain, locale_dir)
         )
         # and register stubs for _ and N_
-        __builtin__.__dict__['_'] = lambda msg: msg
-        __builtin__.__dict__['N_'] = lambda msg: msg
+        __builtin__.__dict__['_'] = translation_stub
+        __builtin__.__dict__['N_'] = translation_stub
         return
 
     if domain in REGISTERED_DOMAINS:

--- a/kano_i18n/init.py
+++ b/kano_i18n/init.py
@@ -18,7 +18,7 @@ def install(app, locale_dir=None):
     global CURRENT_TRANSLATION
 
     # N_() defined globally for deferred translation
-    __builtin__.__dict__['N_'] = lambda msg: msg
+    __builtin__.__dict__['N_'] = lambda msg: unicode(msg)
 
     trans = gettext.translation(app, localedir=locale_dir, fallback=True, codeset=None)
     trans.install(True, names=None)

--- a/tests/dev_locale/test_fake_locale.py
+++ b/tests/dev_locale/test_fake_locale.py
@@ -1,4 +1,11 @@
-# coding:utf8
+# coding: utf-8
+# test_fake_locale.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Tests for fake_locale script
+#
 
 from dev_locale.translate import trans_str
 

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -148,6 +148,14 @@ def test_register_domain_stubs(tmpdir, test_env):
     assert _('Hi') == 'Hi'
     assert _('nudge nudge') == 'nudge nudge'
 
+    # when using stubs ensure all strings are ascii encoded
+    assert type(_(u'¡Hola!')) is str
+    assert type(N_(u'¡Hola!')) is str
+
+    # shouldn't throw error
+    assert _(u'¡Hola!').decode('ascii') == '?Hola!'
+
     install('test-app')
 
     assert _('nudge nudge') == 'wink wink'  # Translation comes from domain-1
+    assert type(_('hi!')) is unicode

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -1,4 +1,12 @@
 # coding: utf-8
+# test_init.py
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Tests for kano_i18n.init
+#
+
 import base64
 import os
 import pytest

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import base64
 import os
 import pytest
@@ -119,5 +120,26 @@ def test_N__deffered_translation():
 
     assert 'N_' in __builtin__.__dict__
 
-    translated_string = N_('foo')
+    translated_string = N_('¡Hola!')
     assert isinstance(translated_string, unicode)
+
+    translated_string = N_(u'¡Hola!')
+    assert isinstance(translated_string, unicode)
+
+
+def test_register_domain_stubs(tmpdir, test_env):
+    test_env['LANG'] = 'en_GB'
+    locale_dir = tmpdir.ensure('en_GB', 'LC_MESSAGES', dir=True)
+
+    domain1_mo = os.path.join(locale_dir.strpath, 'domain-1.mo')
+    with open(domain1_mo, 'wb') as fp:
+        fp.write(base64.decodestring(GNU_MO_DATA))
+
+    register_domain('domain-1', locale_dir=tmpdir.strpath)
+
+    assert _('Hi') == 'Hi'
+    assert _('nudge nudge') == 'nudge nudge'
+
+    install('test-app')
+
+    assert _('nudge nudge') == 'wink wink'  # Translation comes from domain-1

--- a/tests/kano_i18n/test_init.py
+++ b/tests/kano_i18n/test_init.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import pytest
+import __builtin__
 from gettext import GNUTranslations, NullTranslations
 from test.test_support import EnvironmentVarGuard
 
@@ -111,3 +112,12 @@ def test_register_domain_deffered():
     assert current_translation._fallback is not None  # domain-1
     assert current_translation._fallback._fallback is not None  # domain-2
     assert current_translation._fallback._fallback._fallback is None
+
+
+def test_N__deffered_translation():
+    install('app-domain')
+
+    assert 'N_' in __builtin__.__dict__
+
+    translated_string = N_('foo')
+    assert isinstance(translated_string, unicode)


### PR DESCRIPTION
To match `_(` always returning unicode: https://hg.python.org/cpython/file/2.7/Lib/gettext.py#l246